### PR TITLE
Add back (off-by-default) "soft-aes" feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
     - name: "Rust: stable (wasm32)"
       rust: stable
       env: []
-      script: cargo build --target wasm32-unknown-unknown --no-default-features --release
+      script: cargo build --target wasm32-unknown-unknown --no-default-features --features=soft-aes --release
 
 install:
   - rustup component add rustfmt
@@ -39,9 +39,12 @@ install:
 script:
   - cargo fmt --all -- --check
   - cargo clippy --all
+  - cargo build --no-default-features --features=soft-aes --release
   - cargo build --no-default-features --release
   - cargo build --release --all --benches
   - cargo test
+  - cargo test --features=soft-aes
   - cargo test --release
+  - cargo test --features=soft-aes --release
   - cargo doc --no-deps
   - cargo audit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ edition     = "2018"
 crate-type = ["rlib", "staticlib"]
 
 [dependencies]
-aes = { version = "0.3", default-features = false }
+aes = { version = "0.3", default-features = false, optional = true }
 byteorder = { version = "1.2", default-features = false, optional = true }
 cmac = { version = "0.2", default-features = false }
 crypto-mac = { version = "0.7", default-features = false }
@@ -31,6 +31,9 @@ stream-cipher = { version = "0.3", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "0.5", default-features = false }
 
+[target.'cfg(all(target_feature="aes", target_feature = "sse2", any(target_arch = "x86_64", target_arch = "x86")))'.dependencies]
+aesni = { version = "0.6", default-features = false }
+
 [dev-dependencies]
 subtle-encoding = "0.3"
 serde_json = "1"
@@ -39,6 +42,8 @@ serde_json = "1"
 alloc = []
 default = ["std", "stream"]
 nightly = ["zeroize/nightly"]
+soft-aes = ["aes"]
+
 std = ["alloc"]
 stream = ["byteorder"]
 

--- a/src/aead.rs
+++ b/src/aead.rs
@@ -2,10 +2,10 @@
 //! Symmetric encryption which ensures message confidentiality, integrity,
 //! and authenticity.
 
-use crate::{error::Error, siv::Siv};
+use crate::{error::Error, siv::Siv, Aes128, Aes256};
 #[cfg(feature = "alloc")]
 use crate::{prelude::*, IV_SIZE};
-use aes::{Aes128, Aes256};
+
 use cmac::Cmac;
 use crypto_mac::Mac;
 use ctr::Ctr128;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,12 @@ pub use crate::{
     siv::{s2v, Aes128PmacSiv, Aes128Siv, Aes256PmacSiv, Aes256Siv},
 };
 
+#[cfg(feature = "soft-aes")]
+pub(crate) use aes::{Aes128, Aes256};
+
+#[cfg(not(feature = "soft-aes"))]
+pub(crate) use aesni::{Aes128, Aes256};
+
 /// Size of the (synthetic) initialization vector in bytes
 pub const IV_SIZE: usize = 16;
 

--- a/src/siv.rs
+++ b/src/siv.rs
@@ -3,8 +3,7 @@
 
 #[cfg(feature = "alloc")]
 use crate::prelude::*;
-use crate::{error::Error, IV_SIZE};
-use aes::{Aes128, Aes256};
+use crate::{error::Error, Aes128, Aes256, IV_SIZE};
 use cmac::Cmac;
 use crypto_mac::Mac;
 use ctr::Ctr128;


### PR DESCRIPTION
The `aes` crate v0.3 eliminated feature-gated fallback to soft AES.

This adds back a `soft-aes` feature to opt-in to a software implementation of AES on platforms where a hardware implementation is not available.

Right now the only supported hardware implementation is AES-NI. This approach mirrors the target gating used by the `aes` crate, and therefore unless the `soft-aes` feature is enabled this crate
will not compile on any other architecture besides x86(-64) with AES-NI target features enabled.