### PR TITLE
Add back C binding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ os:
   - windows
 
 env:
-  - RUSTFLAGS=-Ctarget-feature=+aes
+  - RUSTFLAGS="-Ctarget-feature=+aes,+ssse3" RUSTDOCFLAGS="-Ctarget-feature=+aes,+ssse3"
 
 matrix:
   fast_finish: true
@@ -25,6 +25,9 @@ matrix:
     # improvements to Travis Windows support
     - os: windows
   include:
+    - name: "Rust: stable (C ABI)"
+      rust: stable
+      script: cd tests/ffi && make
     - name: "Rust: stable (wasm32)"
       rust: stable
       env: []
@@ -39,6 +42,8 @@ install:
 script:
   - cargo fmt --all -- --check
   - cargo clippy --all
+  - cargo check
+  - cargo audit
   - cargo build --no-default-features --features=soft-aes --release
   - cargo build --no-default-features --release
   - cargo build --release --all --benches
@@ -47,4 +52,3 @@ script:
   - cargo test --release
   - cargo test --features=soft-aes --release
   - cargo doc --no-deps
-  - cargo audit

--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ To enable hardware accelerated AES support on x86/x86_64 using [Intel AES-NI]
 instructions, you will need to pass the following `RUSTFLAGS`:
 
 ```
-RUSTFLAGS=-Ctarget-feature=+aes
+RUSTFLAGS=-Ctarget-feature=+aes,+ssse3
 ```
 
 You can configure your `~/.cargo/config` to always pass these flags:
 
 ```toml
 [build]
-rustflags = ["-Ctarget-feature=+aes"]
+rustflags = ["-Ctarget-feature=+aes,+ssse3"]
 ```
 
 ## Help and Discussion

--- a/include/miscreant.h
+++ b/include/miscreant.h
@@ -16,7 +16,7 @@
 extern uint32_t crypto_aead_aes128siv_KEYBYTES;
 
 // AES-128-SIV authenticator tag size
-extern uint32_t crypto_aead_aes128siv_ABYTES;
+extern uint32_t crypto_aead_aes128siv_TAGBYTES;
 
 // AES-128-SIV authenticated encryption
 // Requires *ctlen_p == msglen + 16
@@ -46,7 +46,7 @@ int crypto_aead_aes128siv_decrypt(
 extern uint32_t crypto_aead_aes256siv_KEYBYTES;
 
 // AES-256-SIV authenticator tag size
-extern uint32_t crypto_aead_aes256siv_ABYTES;
+extern uint32_t crypto_aead_aes256siv_TAGBYTES;
 
 // AES-256-SIV authenticated encryption
 // Requires *ctlen_p == msglen + 16
@@ -76,7 +76,7 @@ int crypto_aead_aes256siv_decrypt(
 extern uint32_t crypto_aead_aes128pmacsiv_KEYBYTES;
 
 // AES-128-PMAC-SIV authenticator tag size
-extern uint32_t crypto_aead_aes128pmacsiv_ABYTES;
+extern uint32_t crypto_aead_aes128pmacsiv_TAGBYTES;
 
 // AES-128-SIV authenticated encryption
 // Requires *ctlen_p == msglen + 16
@@ -106,7 +106,7 @@ int crypto_aead_aes128pmacsiv_decrypt(
 extern uint32_t crypto_aead_aes256pmacsiv_KEYBYTES;
 
 // AES-256-PMAC-SIV authenticator tag size
-extern uint32_t crypto_aead_aes256pmacsiv_ABYTES;
+extern uint32_t crypto_aead_aes256pmacsiv_TAGBYTES;
 
 // AES-256-PMAC-SIV authenticated encryption
 // Requires *ctlen_p == msglen + 16

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,0 +1,271 @@
+//! `ffi.rs`: Foreign Function Interface providing C ABI
+//!
+//! TODO: replace this with cbindgen?
+
+// This is the only code in Miscreant allowed to be unsafe
+#![allow(unsafe_code, non_upper_case_globals, unknown_lints)]
+#![allow(clippy::too_many_arguments)]
+
+use crate::{Aead, Aes128PmacSivAead, Aes128SivAead, Aes256PmacSivAead, Aes256SivAead};
+use core::{ptr, slice};
+use generic_array::typenum::marker_traits::Unsigned;
+
+//
+// AES-128-SIV AEAD
+//
+
+/// AES-128-SIV AEAD: authenticated encryption
+#[no_mangle]
+pub unsafe extern "C" fn crypto_aead_aes128siv_encrypt(
+    ct: *mut u8,
+    ctlen_p: *mut u64,
+    msg: *const u8,
+    msglen: u64,
+    nonce: *const u8,
+    noncelen: u64,
+    ad: *const u8,
+    adlen: u64,
+    key: *const u8,
+) -> i32 {
+    aead_encrypt::<Aes128SivAead>(ct, ctlen_p, msg, msglen, nonce, noncelen, ad, adlen, key)
+}
+
+/// AES-128-SIV AEAD: authenticated decryption
+#[no_mangle]
+pub unsafe extern "C" fn crypto_aead_aes128siv_decrypt(
+    msg: *mut u8,
+    msglen_p: *mut u64,
+    ct: *const u8,
+    ctlen: u64,
+    nonce: *const u8,
+    noncelen: u64,
+    ad: *const u8,
+    adlen: u64,
+    key: *const u8,
+) -> i32 {
+    aead_decrypt::<Aes128SivAead>(msg, msglen_p, ct, ctlen, nonce, noncelen, ad, adlen, key)
+}
+
+/// AES-128-SIV key size
+#[no_mangle]
+pub static crypto_aead_aes128siv_KEYBYTES: u32 = 32;
+
+/// AES-128-SIV authenticator tag size
+#[no_mangle]
+pub static crypto_aead_aes128siv_TAGBYTES: u32 = 16;
+
+//
+// AES-256-SIV AEAD
+//
+
+/// AES-256-SIV AEAD: authenticated encryption
+#[no_mangle]
+pub unsafe extern "C" fn crypto_aead_aes256siv_encrypt(
+    ct: *mut u8,
+    ctlen_p: *mut u64,
+    msg: *const u8,
+    msglen: u64,
+    nonce: *const u8,
+    noncelen: u64,
+    ad: *const u8,
+    adlen: u64,
+    key: *const u8,
+) -> i32 {
+    aead_encrypt::<Aes256SivAead>(ct, ctlen_p, msg, msglen, nonce, noncelen, ad, adlen, key)
+}
+
+/// AES-256-SIV AEAD: authenticated decryption
+#[no_mangle]
+pub unsafe extern "C" fn crypto_aead_aes256siv_decrypt(
+    msg: *mut u8,
+    msglen_p: *mut u64,
+    ct: *const u8,
+    ctlen: u64,
+    nonce: *const u8,
+    noncelen: u64,
+    ad: *const u8,
+    adlen: u64,
+    key: *const u8,
+) -> i32 {
+    aead_decrypt::<Aes256SivAead>(msg, msglen_p, ct, ctlen, nonce, noncelen, ad, adlen, key)
+}
+
+/// AES-128-SIV key size
+#[no_mangle]
+pub static crypto_aead_aes256siv_KEYBYTES: u32 = 64;
+
+/// AES-128-SIV authenticator tag size
+#[no_mangle]
+pub static crypto_aead_aes256siv_TAGBYTES: u32 = 16;
+
+//
+// AES-128-PMAC-SIV AEAD
+//
+
+/// AES-128-PMAC-SIV AEAD: authenticated encryption
+#[no_mangle]
+pub unsafe extern "C" fn crypto_aead_aes128pmacsiv_encrypt(
+    ct: *mut u8,
+    ctlen_p: *mut u64,
+    msg: *const u8,
+    msglen: u64,
+    nonce: *const u8,
+    noncelen: u64,
+    ad: *const u8,
+    adlen: u64,
+    key: *const u8,
+) -> i32 {
+    aead_encrypt::<Aes128PmacSivAead>(ct, ctlen_p, msg, msglen, nonce, noncelen, ad, adlen, key)
+}
+
+/// AES-128-PMAC-SIV AEAD: authenticated decryption
+#[no_mangle]
+pub unsafe extern "C" fn crypto_aead_aes128pmacsiv_decrypt(
+    msg: *mut u8,
+    msglen_p: *mut u64,
+    ct: *const u8,
+    ctlen: u64,
+    nonce: *const u8,
+    noncelen: u64,
+    ad: *const u8,
+    adlen: u64,
+    key: *const u8,
+) -> i32 {
+    aead_decrypt::<Aes128PmacSivAead>(msg, msglen_p, ct, ctlen, nonce, noncelen, ad, adlen, key)
+}
+
+/// AES-128-PMAC-SIV key size
+#[no_mangle]
+pub static crypto_aead_aes128pmacsiv_KEYBYTES: u32 = 32;
+
+/// AES-128-PMAC-SIV authenticator tag size
+#[no_mangle]
+pub static crypto_aead_aes128pmacsiv_TAGBYTES: u32 = 16;
+
+//
+// AES-256-PMAC-SIV AEAD
+//
+
+/// AES-256-PMAC-SIV AEAD: authenticated encryption
+#[no_mangle]
+pub unsafe extern "C" fn crypto_aead_aes256pmacsiv_encrypt(
+    ct: *mut u8,
+    ctlen_p: *mut u64,
+    msg: *const u8,
+    msglen: u64,
+    nonce: *const u8,
+    noncelen: u64,
+    ad: *const u8,
+    adlen: u64,
+    key: *const u8,
+) -> i32 {
+    aead_encrypt::<Aes256PmacSivAead>(ct, ctlen_p, msg, msglen, nonce, noncelen, ad, adlen, key)
+}
+
+/// AES-256-PMAC-SIV AEAD: authenticated decryption
+#[no_mangle]
+pub unsafe extern "C" fn crypto_aead_aes256pmacsiv_decrypt(
+    msg: *mut u8,
+    msglen_p: *mut u64,
+    ct: *const u8,
+    ctlen: u64,
+    nonce: *const u8,
+    noncelen: u64,
+    ad: *const u8,
+    adlen: u64,
+    key: *const u8,
+) -> i32 {
+    aead_decrypt::<Aes256PmacSivAead>(msg, msglen_p, ct, ctlen, nonce, noncelen, ad, adlen, key)
+}
+
+/// AES-128-SIV key size
+#[no_mangle]
+pub static crypto_aead_aes256pmacsiv_KEYBYTES: u32 = 64;
+
+/// AES-128-SIV authenticator tag size
+#[no_mangle]
+pub static crypto_aead_aes256pmacsiv_TAGBYTES: u32 = 16;
+
+//
+// Generic AEAD encrypt/decrypt
+//
+
+/// Generic C-like interface to AEAD encryption
+unsafe fn aead_encrypt<A: Aead>(
+    ct: *mut u8,
+    ctlen_p: *mut u64,
+    msg: *const u8,
+    msglen: u64,
+    nonce: *const u8,
+    noncelen: u64,
+    ad: *const u8,
+    adlen: u64,
+    key: *const u8,
+) -> i32 {
+    let taglen = A::TagSize::to_usize();
+
+    if *ctlen_p < msglen.checked_add(taglen as u64).expect("overflow") {
+        return -1;
+    }
+
+    *ctlen_p = msglen.checked_add(taglen as u64).expect("overflow");
+    ptr::copy(msg, ct.add(taglen), msglen as usize);
+
+    let key_slice = slice::from_raw_parts(key, A::KeySize::to_usize());
+    let ct_slice = slice::from_raw_parts_mut(ct, *ctlen_p as usize);
+    let nonce_slice = slice::from_raw_parts(nonce, noncelen as usize);
+    let ad_slice = slice::from_raw_parts(ad, adlen as usize);
+
+    A::new(key_slice).seal_in_place(nonce_slice, ad_slice, ct_slice);
+
+    0
+}
+
+/// Generic C-like interface to AEAD decryption
+unsafe fn aead_decrypt<A: Aead>(
+    msg: *mut u8,
+    msglen_p: *mut u64,
+    ct: *const u8,
+    ctlen: u64,
+    nonce: *const u8,
+    noncelen: u64,
+    ad: *const u8,
+    adlen: u64,
+    key: *const u8,
+) -> i32 {
+    let taglen = A::TagSize::to_usize();
+
+    if ctlen < taglen as u64 {
+        return -1;
+    }
+
+    // TODO: support decrypting messages into buffers smaller than the ciphertext
+    if *msglen_p < ctlen {
+        return -1;
+    }
+
+    *msglen_p = ctlen.checked_sub(taglen as u64).expect("underflow");
+    ptr::copy(ct, msg, ctlen as usize);
+
+    let key_slice = slice::from_raw_parts(key, A::KeySize::to_usize());
+    let msg_slice = slice::from_raw_parts_mut(msg, ctlen as usize);
+    let ad_slice = slice::from_raw_parts(ad, adlen as usize);
+    let nonce_slice = slice::from_raw_parts(nonce, noncelen as usize);
+
+    if A::new(key_slice)
+        .open_in_place(nonce_slice, ad_slice, msg_slice)
+        .is_err()
+    {
+        return -1;
+    }
+
+    // Move the message to the beginning of the buffer
+    ptr::copy(msg.add(taglen), msg, *msglen_p as usize);
+
+    // Zero out the end of the buffer
+    for c in msg_slice[*msglen_p as usize..].iter_mut() {
+        *c = 0;
+    }
+
+    0
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,13 +15,13 @@
 //! To access these features, you will need both a relatively recent
 //! Rust nightly and to pass the following as RUSTFLAGS:
 //!
-//! `RUSTFLAGS=-Ctarget-feature=+aes`
+//! `RUSTFLAGS=-Ctarget-feature=+aes,+ssse3`
 //!
 //! You can configure your `~/.cargo/config` to always pass these flags:
 //!
 //! ```toml
 //! [build]
-//! rustflags = ["-Ctarget-feature=+aes"]
+//! rustflags = ["-Ctarget-feature=+aes,+ssse3"]
 //! ```
 
 #![no_std]
@@ -37,12 +37,26 @@
 #![cfg_attr(all(feature = "nightly", not(feature = "std")), feature(alloc))]
 #![doc(html_root_url = "https://docs.rs/miscreant/0.4.0-beta2")]
 
+#[cfg(not(any(
+    feature = "soft-aes",
+    all(
+        target_feature = "aes",
+        target_feature = "sse2",
+        any(target_arch = "x86_64", target_arch = "x86")
+    )
+)))]
+compile_error!(
+    "unsupported target platform. Either enable appropriate target-features (+aes,+ssse3) \
+     in RUSTFLAGS or enable the 'soft-aes' cargo feature to fallback to a software AES implementation"
+);
+
 #[cfg(feature = "std")]
 #[macro_use]
 extern crate std;
 
 pub mod aead;
 mod error;
+pub mod ffi;
 mod prelude;
 pub mod siv;
 #[cfg(feature = "stream")]

--- a/tests/ffi/.gitignore
+++ b/tests/ffi/.gitignore
@@ -1,0 +1,2 @@
+*.o
+ffi_test

--- a/tests/ffi/Makefile
+++ b/tests/ffi/Makefile
@@ -1,0 +1,14 @@
+CFLAGS=-I../../include -Wall -O3 -pedantic -std=c99
+
+libmiscreant = ../../target/release/libmiscreant.a
+
+all: ffi_test
+
+clean:
+	rm -f *.o ffi_test
+
+$(libmiscreant):
+	cd ../.. && cargo build --no-default-features --release
+
+ffi_test: ffi_test.o $(libmiscreant)
+	$(CC) $(LDFLAGS) -o ffi_test ffi_test.o $(libmiscreant)

--- a/tests/ffi/ffi_test.c
+++ b/tests/ffi/ffi_test.c
@@ -1,0 +1,188 @@
+/**
+ * Test for the Miscreant C ABI
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include "miscreant.h"
+
+void test_aead_aes128siv() {
+    // AES-SIV Nonce-based Authenticated Encryption Example #1
+    const uint8_t key[] = "\x7F\x7E\x7D\x7C\x7B\x7A\x79\x78\x77\x76\x75\x74\x73\x72\x71\x70\x40\x41\x42\x43\x44\x45\x46\x47\x48\x49\x4A\x4B\x4C\x4D\x4E\x4F";
+    const uint8_t nonce[] = "\x09\xF9\x11\x02\x9D\x74\xE3\x5B\xD8\x41\x56\xC5\x63\x56\x88\xC0";
+    const uint8_t ad[] = "\x00\x11\x22\x33\x44\x55\x66\x77\x88\x99\xAA\xBB\xCC\xDD\xEE\xFF\xDE\xAD\xDA\xDA\xDE\xAD\xDA\xDA\xFF\xEE\xDD\xCC\xBB\xAA\x99\x88\x77\x66\x55\x44\x33\x22\x11\x00";
+    const uint8_t pt[] = "\x74\x68\x69\x73\x20\x69\x73\x20\x73\x6F\x6D\x65\x20\x70\x6C\x61\x69\x6E\x74\x65\x78\x74\x20\x74\x6F\x20\x65\x6E\x63\x72\x79\x70\x74\x20\x75\x73\x69\x6E\x67\x20\x53\x49\x56\x2D\x41\x45\x53";
+    const uint8_t ct[] = "\x85\x82\x5E\x22\xE9\x0C\xF2\xDD\xDA\x2C\x54\x8D\xC7\xC1\xB6\x31\x0D\xCD\xAC\xA0\xCE\xBF\x9D\xC6\xCB\x90\x58\x3F\x5B\xF1\x50\x6E\x02\xCD\x48\x83\x2B\x00\xE4\xE5\x98\xB2\xB2\x2A\x53\xE6\x19\x9D\x4D\xF0\xC1\x66\x6A\x35\xA0\x43\x3B\x25\x0D\xC1\x34\xD7\x76";
+
+    uint8_t buf[sizeof(ct)] = {0};
+    uint64_t buflen = sizeof(buf) - 1;
+
+    assert(sizeof(pt) + crypto_aead_aes128siv_TAGBYTES == sizeof(buf));
+
+    // Test encryption
+    if(crypto_aead_aes128siv_encrypt(
+        buf, &buflen,
+        pt, sizeof(pt) - 1,
+        nonce, sizeof(nonce) - 1,
+        ad, sizeof(ad) - 1,
+        key
+     ) != 0) {
+        fputs("error: aes128siv AEAD: encryption failure\n", stderr);
+        abort();
+    }
+
+    assert(memcmp(buf, ct, sizeof(ct) - 1) == 0);
+
+    // Test decryption
+    if(crypto_aead_aes128siv_decrypt(
+        buf, &buflen,
+        ct, sizeof(ct) - 1,
+        nonce, sizeof(nonce) - 1,
+        ad, sizeof(ad) - 1,
+        key
+     ) != 0) {
+        fputs("error: aes128siv AEAD: decryption failure\n", stderr);
+        abort();
+    }
+
+    assert(memcmp(buf, pt, sizeof(pt) - 1) == 0);
+}
+
+void test_aead_aes256siv() {
+    // AES-SIV Nonce-based Authenticated Encryption Example #2
+    const uint8_t key[] = "\xFF\xFE\xFD\xFC\xFB\xFA\xF9\xF8\xF7\xF6\xF5\xF4\xF3\xF2\xF1\xF0\x6F\x6E\x6D\x6C\x6B\x6A\x69\x68\x67\x66\x65\x64\x63\x62\x61\x60\xF0\xF1\xF2\xF3\xF4\xF5\xF6\xF7\xF8\xF9\xFA\xFB\xFC\xFD\xFE\xFF\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F";
+    const uint8_t nonce[] = "\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1A\x1B\x1C\x1D\x1E\x1F\x20\x21\x22\x23\x24\x25\x26\x27";
+    const uint8_t ad[] = "";
+    const uint8_t pt[] = "\x11\x22\x33\x44\x55\x66\x77\x88\x99\xAA\xBB\xCC\xDD\xEE";
+    const uint8_t ct[] = "\xE6\x18\xD2\xD6\xA8\x6B\x50\xA8\xD7\xDF\x82\xAB\x34\xAA\x95\x0A\xB3\x19\xD7\xFC\x15\xF7\xCD\x1E\xA9\x9B\x1A\x03\x3F\x20";
+
+    uint8_t buf[sizeof(ct)] = {0};
+    uint64_t buflen = sizeof(buf) - 1;
+
+    assert(sizeof(pt) + crypto_aead_aes256siv_TAGBYTES == sizeof(buf));
+
+    // Test encryption
+    if(crypto_aead_aes256siv_encrypt(
+        buf, &buflen,
+        pt, sizeof(pt) - 1,
+        nonce, sizeof(nonce) - 1,
+        ad, sizeof(ad) - 1,
+        key
+     ) != 0) {
+        fputs("error: aes256siv AEAD: encryption failure\n", stderr);
+        abort();
+    }
+
+    assert(memcmp(buf, ct, sizeof(ct) - 1) == 0);
+
+    // Test decryption
+    if(crypto_aead_aes256siv_decrypt(
+        buf, &buflen,
+        ct, sizeof(ct) - 1,
+        nonce, sizeof(nonce) - 1,
+        ad, sizeof(ad) - 1,
+        key
+     ) != 0) {
+        fputs("error: aes256siv AEAD: decryption failure\n", stderr);
+        abort();
+    }
+
+    assert(memcmp(buf, pt, sizeof(pt) - 1) == 0);
+}
+
+void test_aead_aes128pmacsiv() {
+    // AES-PMAC-SIV Authenticted Encryption with Associated Data Example
+    const uint8_t key[] = "\x7F\x7E\x7D\x7C\x7B\x7A\x79\x78\x77\x76\x75\x74\x73\x72\x71\x70\x40\x41\x42\x43\x44\x45\x46\x47\x48\x49\x4A\x4B\x4C\x4D\x4E\x4F";
+    const uint8_t nonce[] = "\x09\xF9\x11\x02\x9D\x74\xE3\x5B\xD8\x41\x56\xC5\x63\x56\x88\xC0";
+    const uint8_t ad[] = "\x00\x11\x22\x33\x44\x55\x66\x77\x88\x99\xAA\xBB\xCC\xDD\xEE\xFF\xDE\xAD\xDA\xDA\xDE\xAD\xDA\xDA\xFF\xEE\xDD\xCC\xBB\xAA\x99\x88\x77\x66\x55\x44\x33\x22\x11\x00";
+    const uint8_t pt[] = "\x74\x68\x69\x73\x20\x69\x73\x20\x73\x6F\x6D\x65\x20\x70\x6C\x61\x69\x6E\x74\x65\x78\x74\x20\x74\x6F\x20\x65\x6E\x63\x72\x79\x70\x74\x20\x75\x73\x69\x6E\x67\x20\x53\x49\x56\x2D\x41\x45\x53";
+    const uint8_t ct[] = "\x14\x63\xD1\x11\x9B\x2A\x27\x97\x24\x1B\xB1\x67\x46\x33\xDF\xF1\x3B\x9D\xE1\x1E\x5E\x2F\x52\x60\x48\xB3\x6C\x40\xC7\x72\x26\x67\xB2\x95\x70\x18\x02\x3B\xF0\xE5\x27\x92\xB7\x03\xA0\x1E\x88\xAA\xCD\x49\x89\x8C\xEC\xFC\xE9\x43\xD7\xF6\x1A\x23\x37\xA0\x97";
+
+    uint8_t buf[sizeof(ct)] = {0};
+    uint64_t buflen = sizeof(buf) - 1;
+
+    assert(sizeof(pt) + crypto_aead_aes128pmacsiv_TAGBYTES == sizeof(buf));
+
+    // Test encryption
+    if(crypto_aead_aes128pmacsiv_encrypt(
+        buf, &buflen,
+        pt, sizeof(pt) - 1,
+        nonce, sizeof(nonce) - 1,
+        ad, sizeof(ad) - 1,
+        key
+     ) != 0) {
+        fputs("error: aes128pmacsiv AEAD: encryption failure\n", stderr);
+        abort();
+    }
+
+    assert(memcmp(buf, ct, sizeof(ct) - 1) == 0);
+
+    // Test decryption
+    if(crypto_aead_aes128pmacsiv_decrypt(
+        buf, &buflen,
+        ct, sizeof(ct) - 1,
+        nonce, sizeof(nonce) - 1,
+        ad, sizeof(ad) - 1,
+        key
+     ) != 0) {
+        fputs("error: aes128pmacsiv AEAD: decryption failure\n", stderr);
+        abort();
+    }
+
+    assert(memcmp(buf, pt, sizeof(pt) - 1) == 0);
+}
+
+void test_aead_aes256pmacsiv() {
+    // AES-256-PMAC-SIV Authenticted Encryption with Associated Data Example #2
+    const uint8_t key[] = "\xFF\xFE\xFD\xFC\xFB\xFA\xF9\xF8\xF7\xF6\xF5\xF4\xF3\xF2\xF1\xF0\x6F\x6E\x6D\x6C\x6B\x6A\x69\x68\x67\x66\x65\x64\x63\x62\x61\x60\xF0\xF1\xF2\xF3\xF4\xF5\xF6\xF7\xF8\xF9\xFA\xFB\xFC\xFD\xFE\xFF\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F";
+    const uint8_t nonce[] = "\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1A\x1B\x1C\x1D\x1E\x1F\x20\x21\x22\x23\x24\x25\x26\x27";
+    const uint8_t ad[] = "";
+    const uint8_t pt[] = "\x11\x22\x33\x44\x55\x66\x77\x88\x99\xAA\xBB\xCC\xDD\xEE";
+    const uint8_t ct[] = "\x06\x23\xA7\x27\x5A\xFD\x50\x82\x03\x5E\x43\xB0\xDC\xAF\xE3\xA8\x91\xC2\xB8\xEE\xD2\xB1\xA0\x7F\x0D\xD2\x51\x80\xE0\x72";
+
+    uint8_t buf[sizeof(ct)] = {0};
+    uint64_t buflen = sizeof(buf) - 1;
+
+    assert(sizeof(pt) + crypto_aead_aes256pmacsiv_TAGBYTES == sizeof(buf));
+
+    // Test encryption
+    if(crypto_aead_aes256pmacsiv_encrypt(
+        buf, &buflen,
+        pt, sizeof(pt) - 1,
+        nonce, sizeof(nonce) - 1,
+        ad, sizeof(ad) - 1,
+        key
+     ) != 0) {
+        fputs("error: aes256pmacsiv AEAD: encryption failure\n", stderr);
+        abort();
+    }
+
+    assert(memcmp(buf, ct, sizeof(ct) - 1) == 0);
+
+    // Test decryption
+    if(crypto_aead_aes256pmacsiv_decrypt(
+        buf, &buflen,
+        ct, sizeof(ct) - 1,
+        nonce, sizeof(nonce) - 1,
+        ad, sizeof(ad) - 1,
+        key
+     ) != 0) {
+        fputs("error: aes256pmacsiv AEAD: decryption failure\n", stderr);
+        abort();
+    }
+
+    assert(memcmp(buf, pt, sizeof(pt) - 1) == 0);
+}
+
+int main(int argc, char **argv) {
+    test_aead_aes128siv();
+    test_aead_aes256siv();
+    test_aead_aes128pmacsiv();
+    test_aead_aes256pmacsiv();
+
+    printf("%s: success\n", argv[0]);
+    return 0;
+}


### PR DESCRIPTION
This re-adds the C FFI/ABI which was removed in 7728e92 (GitHub PR #6).

It was originally removed to simplify that PR, and in the hopes it could be replaced automatically with cbindgen, but the latter was complicated by this crate's use of generic-array.

Switching to cbindgen might make more sense after const generics land and it becomes possible to generate some functions specialized to particular associated constants.