### PR TITLE
v0.4.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,51 +1,30 @@
+## [0.4.0] (2019-01-12)
+
+- Add back (off-by-default) `soft-aes` feature ([#10])
+- Convert benchmark suite to use criterion.rs ([#7])
+- Refactor using `ctr` and `stream-cipher` crates ([#6])
+- Update dependencies (closes #2) ([#4])
+- Update to Rust 2018 edition ([#3])
+
 ## [0.3.0] (2017-12-25)
 
-[0.3.0]: https://github.com/miscreant/miscreant/compare/v0.2.0...v0.3.0
-
-* STREAM support (all languages)
-* AEAD APIs: TypeScript, Rust
-* Rust internals based on RustCrypto project providing ~10% faster performance
-
-### Notable Pull Requests
-
-* [#100](https://github.com/miscreant/miscreant/pull/100)
-  rust: Use AES-CTR implementation from the `aesni` crate
-* [#102](https://github.com/miscreant/miscreant/pull/102)
-  rust: Use cmac and pmac crates from RustCrypto
-* [#103](https://github.com/miscreant/miscreant/pull/103)
-  rust: DRY out and abstract SIV+CTR implementations across key sizes
-* [#104](https://github.com/miscreant/miscreant/pull/104)
-  rust: Deny unsafe_code
-* [#105](https://github.com/miscreant/miscreant/pull/105)
-  rust: AEAD API
-* [#112](https://github.com/miscreant/miscreant/pull/112)
-  rust: STREAM implementation
-* [#117](https://github.com/miscreant/miscreant/pull/117)
-  rust: "std" feature and allocating APIs
-* [#120](https://github.com/miscreant/miscreant/pull/120)
-  rust: Dual license under MIT/Apache 2.0
-* [#122](https://github.com/miscreant/miscreant/pull/122)
-  ruby: STREAM implementation
-* [#124](https://github.com/miscreant/miscreant/pull/124)
-  python: STREAM implementation
-* [#126](https://github.com/miscreant/miscreant/pull/126)
-  go: Switch to using math.TrailingZeros in PMAC (requires Go 1.9+)
-* [#127](https://github.com/miscreant/miscreant/pull/127)
-  js: AEAD API
-* [#131](https://github.com/miscreant/miscreant/pull/131)
-  js: STREAM implementation
-* [#132](https://github.com/miscreant/miscreant/pull/132)
-  go: STREAM implementation
+- STREAM support
+- AEAD APIs: TypeScript, Rust
+- Rust internals based on RustCrypto project providing ~10% faster performance
 
 ## [0.2.0] (2017-10-01)
 
-[0.2.0]: https://github.com/miscreant/miscreant/compare/v0.1.0...v0.2.0
-
-* AES-PMAC-SIV support (all languages)
-* AEAD APIs with test vectors: Go, Ruby, Python
-* Various breaking API changes from 0.1.0, but hopefully no one was using a v0.1
-  crypto library anyway.
+- AES-PMAC-SIV support
 
 # 0.1.0 (2017-07-31)
 
-* Initial release
+- Initial release
+
+[0.4.0]: https://github.com/miscreant/miscreant.rs/pull/12
+[#10]: https://github.com/miscreant/miscreant.rs/pull/12
+[#7]: https://github.com/miscreant/miscreant.rs/pull/7
+[#6]: https://github.com/miscreant/miscreant.rs/pull/6
+[#4]: https://github.com/miscreant/miscreant.rs/pull/4
+[#3]: https://github.com/miscreant/miscreant.rs/pull/3
+[0.3.0]: https://github.com/miscreant/miscreant.rs/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/miscreant/miscreant.rs/compare/v0.1.0...v0.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ description = """
               authenticated encryption (MRAE) including AES-SIV (RFC 5297),
               AES-PMAC-SIV, and the STREAM segmented encryption construction.
               """
-version     = "0.4.0-beta2" # Also update html_root_url in lib.rs when bumping this
+version     = "0.4.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 or MIT"
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 homepage    = "https://miscreant.io"
@@ -17,6 +17,9 @@ edition     = "2018"
 
 [lib]
 crate-type = ["rlib", "staticlib"]
+
+[badges]
+circle-ci = { repository = "miscreant/miscreant.rs" }
 
 [dependencies]
 aes = { version = "0.3", default-features = false, optional = true }

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ conditions.
 
 ## License
 
-Copyright (c) 2017-2018 [The Miscreant Developers][AUTHORS].
+Copyright (c) 2017-2019 [The Miscreant Developers][AUTHORS].
 
 **miscreant.rs** is licensed under either of:
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@
     unused_qualifications
 )]
 #![cfg_attr(all(feature = "nightly", not(feature = "std")), feature(alloc))]
-#![doc(html_root_url = "https://docs.rs/miscreant/0.4.0-beta2")]
+#![doc(html_root_url = "https://docs.rs/miscreant/0.4.0")]
 
 #[cfg(not(any(
     feature = "soft-aes",


### PR DESCRIPTION
- Add back (off-by-default) `soft-aes` feature (#10)
- Convert benchmark suite to use criterion.rs (#7)
- Refactor using `ctr` and `stream-cipher` crates (#6)
- Update dependencies (closes #2) (#4)
- Update to Rust 2018 edition (#3)