### PR TITLE
Cargo.toml: Fix license string

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ description = """
               AES-PMAC-SIV, and the STREAM segmented encryption construction.
               """
 version     = "0.4.0" # Also update html_root_url in lib.rs when bumping this
-license     = "Apache-2.0 or MIT"
+license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 homepage    = "https://miscreant.io"
 repository  = "https://github.com/miscreant/miscreant.rs"


### PR DESCRIPTION
The 'OR' separator needs to be capitalized.