### PR TITLE
v0.4.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## [0.4.1] (2019-01-12)
+
+- Cargo.toml: Fix docs.rs config, CI badge, and license string ([#13], [#14])
+
 ## [0.4.0] (2019-01-12)
 
 - Add back (off-by-default) `soft-aes` feature ([#10])
@@ -20,6 +24,9 @@
 
 - Initial release
 
+[0.4.1]: https://github.com/miscreant/miscreant.rs/pull/15
+[#14]: https://github.com/miscreant/miscreant.rs/pull/14
+[#13]: https://github.com/miscreant/miscreant.rs/pull/13
 [0.4.0]: https://github.com/miscreant/miscreant.rs/pull/12
 [#10]: https://github.com/miscreant/miscreant.rs/pull/12
 [#7]: https://github.com/miscreant/miscreant.rs/pull/7

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ description = """
               authenticated encryption (MRAE) including AES-SIV (RFC 5297),
               AES-PMAC-SIV, and the STREAM segmented encryption construction.
               """
-version     = "0.4.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.4.1" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 homepage    = "https://miscreant.io"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# miscreant.rs
+# <img alt="miscreant." src="https://miscreant.io/images/miscreant.svg">
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@
     unused_qualifications
 )]
 #![cfg_attr(all(feature = "nightly", not(feature = "std")), feature(alloc))]
-#![doc(html_root_url = "https://docs.rs/miscreant/0.4.0")]
+#![doc(html_root_url = "https://docs.rs/miscreant/0.4.1")]
 
 #[cfg(not(any(
     feature = "soft-aes",


### PR DESCRIPTION
- Cargo.toml: Fix docs.rs config, CI badge, and license string ([#13], [#14])