### PR TITLE
v0.4.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## [0.4.2] (2019-01-12)
+
+- Cargo.toml: Enable `soft-aes` feature in docs.rs metadata ([#16])
+
 ## [0.4.1] (2019-01-12)
 
 - Cargo.toml: Fix docs.rs config, CI badge, and license string ([#13], [#14])
@@ -24,6 +28,8 @@
 
 - Initial release
 
+[0.4.2]: https://github.com/miscreant/miscreant.rs/pull/17
+[#16]: https://github.com/miscreant/miscreant.rs/pull/16
 [0.4.1]: https://github.com/miscreant/miscreant.rs/pull/15
 [#14]: https://github.com/miscreant/miscreant.rs/pull/14
 [#13]: https://github.com/miscreant/miscreant.rs/pull/13

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ description = """
               authenticated encryption (MRAE) including AES-SIV (RFC 5297),
               AES-PMAC-SIV, and the STREAM segmented encryption construction.
               """
-version     = "0.4.1" # Also update html_root_url in lib.rs when bumping this
+version     = "0.4.2" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 homepage    = "https://miscreant.io"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@
 //! ```
 
 #![no_std]
+#![cfg_attr(all(feature = "nightly", not(feature = "std")), feature(alloc))]
 #![deny(
     warnings,
     missing_docs,
@@ -34,8 +35,7 @@
     unused_import_braces,
     unused_qualifications
 )]
-#![cfg_attr(all(feature = "nightly", not(feature = "std")), feature(alloc))]
-#![doc(html_root_url = "https://docs.rs/miscreant/0.4.1")]
+#![doc(html_root_url = "https://docs.rs/miscreant/0.4.2")]
 
 #[cfg(not(any(
     feature = "soft-aes",


### PR DESCRIPTION
- Cargo.toml: Enable `soft-aes` feature in https://docs.rs metadata (#16)