### PR TITLE
Cargo.toml: Fix zeroize feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ serde_json = "1"
 [features]
 alloc = []
 default = ["std", "stream"]
-nightly = ["zeroize/nightly"]
 soft-aes = ["aes"]
 
 std = ["alloc"]


### PR DESCRIPTION
1.0 does not have the `nightly` cargo feature