### PR TITLE
Remove `soft-aes` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["rlib", "staticlib"]
 travis-ci = { repository = "miscreant/miscreant.rs" }
 
 [dependencies]
-aes = { version = "0.3", default-features = false, optional = true }
+aes = { version = "0.3", default-features = false }
 byteorder = { version = "1.2", default-features = false, optional = true }
 cmac = { version = "0.2", default-features = false }
 crypto-mac = { version = "0.7", default-features = false }
@@ -32,10 +32,7 @@ generic-array = { version = "0.12", default-features = false }
 pmac = { version = "0.2", default-features = false }
 stream-cipher = { version = "0.3", default-features = false }
 subtle = { version = "2", default-features = false }
-zeroize = { version = "1.0", default-features = false }
-
-[target.'cfg(all(target_feature="aes", target_feature = "sse2", any(target_arch = "x86_64", target_arch = "x86")))'.dependencies]
-aesni = { version = "0.6", default-features = false }
+zeroize = { version = "1", default-features = false }
 
 [dev-dependencies]
 subtle-encoding = "0.5"
@@ -44,8 +41,6 @@ serde_json = "1"
 [features]
 alloc = []
 default = ["std", "stream"]
-soft-aes = ["aes"]
-
 std = ["alloc"]
 stream = ["byteorder"]
 
@@ -73,6 +68,3 @@ lto = false
 opt-level = 3
 overflow-checks = false
 rpath = false
-
-[package.metadata.docs.rs]
-features = ["soft-aes"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,22 +1,15 @@
 //! `Miscreant`: Misuse resistant symmetric encryption library providing the
 //! AES-SIV (RFC 5297), AES-PMAC-SIV, and STREAM constructions
 //!
-//! ## Build Notes
+//! ## Minimum Supported Rust Version (MSRV)
 //!
-//! miscreant.rs supports Rust 1.31 and later.
-//!
-//! By default the crate will only build on targets which support hardware AES
-//! acceleration, which is presently limited to `x86`/`x86_64` with [AES-NI]
-//! acceleration. On these platforms, you'll need to enable the required target
-//! features.
-//!
-//! Otherwise, you'll need to enable the `soft-aes` cargo feature to support
-//! a software fallback implementation of AES.
+//! - Rust 1.31.0
 //!
 //! ### `x86`/`x86_64` targets with AES-NI support
 //!
-//! To build this crate with hardware acceleration support, set the following
-//! `RUSTFLAGS` environment variable:
+//! To build this crate with hardware acceleration support on `x86`/`x86_64`
+//! targets with [AES-NI] support, set the following `RUSTFLAGS` environment
+//! variable:
 //!
 //! `RUSTFLAGS=-Ctarget-feature=+aes,+ssse3`
 //!
@@ -27,10 +20,7 @@
 //! rustflags = ["-Ctarget-feature=+aes,+ssse3"]
 //! ```
 //!
-//! ### All other targets: software AES fallback
-//!
-//! To enable building with a software fallback implementation of AES rather
-//! than the hardware accelerated version, enable the `soft-aes` cargo feature.
+//! [AES-NI]: https://en.wikipedia.org/wiki/AES_instruction_set#x86_architecture_processors
 
 #![no_std]
 #![cfg_attr(all(feature = "nightly", not(feature = "std")), feature(alloc))]
@@ -44,19 +34,6 @@
     unused_qualifications
 )]
 #![doc(html_root_url = "https://docs.rs/miscreant/0.4.2")]
-
-#[cfg(not(any(
-    feature = "soft-aes",
-    all(
-        target_feature = "aes",
-        target_feature = "sse2",
-        any(target_arch = "x86_64", target_arch = "x86")
-    )
-)))]
-compile_error!(
-    "unsupported target platform. Either enable appropriate target-features (+aes,+ssse3) \
-     in RUSTFLAGS or enable the 'soft-aes' cargo feature to fallback to a software AES implementation"
-);
 
 #[cfg(feature = "std")]
 #[macro_use]
@@ -76,11 +53,7 @@ pub use crate::{
     siv::{s2v, Aes128PmacSiv, Aes128Siv, Aes256PmacSiv, Aes256Siv},
 };
 
-#[cfg(feature = "soft-aes")]
 pub(crate) use aes::{Aes128, Aes256};
-
-#[cfg(not(feature = "soft-aes"))]
-pub(crate) use aesni::{Aes128, Aes256};
 
 /// Size of the (synthetic) initialization vector in bytes
 pub const IV_SIZE: usize = 16;


### PR DESCRIPTION
In preparation for switching to the `aes-siv` crate, this removes the `soft-aes` feature, which no-longer exists in that crate.

Hardware acceleration is now gated entirely by `RUSTFLAGS`.