### PR TITLE
v0.5.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## [0.5.2] (2019-12-04)
+
+- Re-export `SivAead` and `siv` module ([#43])
+
 ## [0.5.1] (2019-12-04)
 
 - Remove crate type overrides ([#41])
@@ -39,6 +43,8 @@
 
 - Initial release
 
+[0.5.2]: https://github.com/miscreant/miscreant.rs/pull/44
+[#43]: https://github.com/miscreant/miscreant.rs/pull/43
 [0.5.1]: https://github.com/miscreant/miscreant.rs/pull/42
 [#41]: https://github.com/miscreant/miscreant.rs/pull/41
 [0.5.0]: https://github.com/miscreant/miscreant.rs/pull/40

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ Symmetric encryption library providing misuse-resistant
 authenticated encryption (MRAE) including AES-SIV (RFC 5297),
 AES-PMAC-SIV, and the STREAM segmented encryption construction.
 """
-version    = "0.5.1" # Also update html_root_url in lib.rs when bumping this
+version    = "0.5.2" # Also update html_root_url in lib.rs when bumping this
 license    = "Apache-2.0 OR MIT"
 authors    = ["Tony Arcieri <bascule@gmail.com>"]
 homepage   = "https://miscreant.io"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 //! [AES-NI]: https://en.wikipedia.org/wiki/AES_instruction_set#x86_architecture_processors
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/miscreant/0.5.1")]
+#![doc(html_root_url = "https://docs.rs/miscreant/0.5.2")]
 #![warn(missing_docs, rust_2018_idioms, unsafe_code, unused_qualifications)]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
- Re-export `SivAead` and `siv` module (#43)